### PR TITLE
Fix default realm types for networked nodes

### DIFF
--- a/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/ValueNodes/Synced/SyncedBoolEntityData.cs
+++ b/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/ValueNodes/Synced/SyncedBoolEntityData.cs
@@ -6,7 +6,7 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared
     public class SyncedBoolNode : SyncedNode
     {
         public override string ObjectType => "SyncedBoolEntityData";
-        public override string ToolTip => "This node syncs a value between all clients connected to the server.";
+        public override string ToolTip => "This node syncs a boolean value between all clients connected to the server.";
 
         public override void OnCreation()
         {

--- a/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/ValueNodes/Synced/SyncedBoolEntityData.cs
+++ b/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/ValueNodes/Synced/SyncedBoolEntityData.cs
@@ -6,7 +6,7 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared
     public class SyncedBoolNode : SyncedNode
     {
         public override string ObjectType => "SyncedBoolEntityData";
-        public override string ToolTip => "This node syncs a boolean between client and server.";
+        public override string ToolTip => "This node syncs a value between all clients connected to the server.";
 
         public override void OnCreation()
         {
@@ -15,9 +15,9 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared
             AddOutput("OnTrue", ConnectionType.Event, Realm.Server);
             AddOutput("OnFalse", ConnectionType.Event, Realm.Server);
 
-            AddInput("SetTrue", ConnectionType.Event, Realm.Client);
-            AddInput("SetFalse", ConnectionType.Event, Realm.Client);
-            AddInput("Toggle", ConnectionType.Event, Realm.Client);
+            AddInput("SetTrue", ConnectionType.Event, Realm.Server);
+            AddInput("SetFalse", ConnectionType.Event, Realm.Server);
+            AddInput("Toggle", ConnectionType.Event, Realm.Server);
         }
     }
 }

--- a/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/ValueNodes/Synced/SyncedItemNode.cs
+++ b/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/ValueNodes/Synced/SyncedItemNode.cs
@@ -1,17 +1,17 @@
-﻿using BlueprintEditorPlugin.Editors.BlueprintEditor.Connections;
+er﻿using BlueprintEditorPlugin.Editors.BlueprintEditor.Connections;
 using BlueprintEditorPlugin.Models.Entities.Networking;
 
 namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared.ValueNodes.Synced
 {
     public abstract class SyncedNode : EntityNode
     {
-        public override string ToolTip => "This node syncs a value between client and server.";
+        public override string ToolTip => "This node syncs a value between all clients connected to the server.";
 
         public override void OnCreation()
         {
             base.OnCreation();
 
-            AddInput("In", ConnectionType.Property, Realm.Client);
+            AddInput("In", ConnectionType.Property, Realm.Server);
             AddOutput("Out", ConnectionType.Property, Realm.Server);
         }
     }

--- a/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/ValueNodes/Synced/SyncedItemNode.cs
+++ b/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/ValueNodes/Synced/SyncedItemNode.cs
@@ -1,4 +1,4 @@
-er﻿using BlueprintEditorPlugin.Editors.BlueprintEditor.Connections;
+﻿using BlueprintEditorPlugin.Editors.BlueprintEditor.Connections;
 using BlueprintEditorPlugin.Models.Entities.Networking;
 
 namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared.ValueNodes.Synced


### PR DESCRIPTION
The input value for SyncedBool, SyncedInt, etc, is of server-realm, not client. Also updated 2 descriptions to be slightly more accurate