### PR TITLE
Fix multiple Crashing Issues

### DIFF
--- a/Editors/BlueprintEditor/NodeWrangler/EntityNodeWrangler.cs
+++ b/Editors/BlueprintEditor/NodeWrangler/EntityNodeWrangler.cs
@@ -112,8 +112,8 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.NodeWrangler
                                 if (InterfaceEoCache.ContainsKey(HashingUtils.SmartHashString(interfaceNode.Header)))
                                 {
                                     App.Logger.LogError("Multiple copies of {0} interfaces exist!", interfaceNode.Header);
-                                            return;
-                                        }
+                                    return;
+                                }
                                 InterfaceEoCache.Add(HashingUtils.SmartHashString(interfaceNode.Header), interfaceNode);
                             } break;
                             case ConnectionType.Link:
@@ -121,8 +121,8 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.NodeWrangler
                                 if (InterfaceLoCache.ContainsKey(HashingUtils.SmartHashString(interfaceNode.Header)))
                                 {
                                     App.Logger.LogError("Multiple copies of {0} interfaces exist!", interfaceNode.Header);
-                                            return;
-                                        }
+                                    return;
+                                }
                                 InterfaceLoCache.Add(HashingUtils.SmartHashString(interfaceNode.Header), interfaceNode);
                             } break;
                             case ConnectionType.Property:
@@ -130,7 +130,7 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.NodeWrangler
                                 if (InterfacePoCache.ContainsKey(HashingUtils.SmartHashString(interfaceNode.Header)))
                                 {
                                     App.Logger.LogError("Multiple copies of {0} interfaces exist!", interfaceNode.Header);
-                                            return;
+                                    return;
                                 }
                                 InterfacePoCache.Add(HashingUtils.SmartHashString(interfaceNode.Header), interfaceNode);
                             } break;

--- a/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/Hubs/BaseHubEntity.cs
+++ b/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/Hubs/BaseHubEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -63,7 +63,12 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared
                         } break;
                         case ItemModifiedTypes.Remove:
                         {
-                            EntityInput input = GetInput((int)args.OldValue, ConnectionType.Property);
+                            int index = Convert.ToInt32(args.OldValue);
+                            EntityInput input = GetInput(index, ConnectionType.Property);
+                            if (input == null)
+                                {
+                                    return;
+                                }
                             RemoveInput(input);
                         } break;
                         case ItemModifiedTypes.Clear:

--- a/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/Logic/Flow/SelectEventEntityData.cs
+++ b/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/Logic/Flow/SelectEventEntityData.cs
@@ -26,9 +26,8 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared
                 if (evnt.IsNull())
                     continue;
 
-                string eventName = (evnt == null || evnt.IsNull()) ? "Event" : evnt.ToString();
-                AddOutput(eventName, ConnectionType.Event, Realm);
-                AddInput($"Select{eventName}", ConnectionType.Event, Realm);
+                AddOutput(evnt.ToString(), ConnectionType.Event, Realm);
+                AddInput($"Select{evnt.ToString()}", ConnectionType.Event);
             }
         }
 

--- a/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/Logic/Flow/SelectEventEntityData.cs
+++ b/Editors/BlueprintEditor/Nodes/TypeMapping/Shared/Logic/Flow/SelectEventEntityData.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using BlueprintEditorPlugin.Editors.BlueprintEditor.Connections;
@@ -25,9 +25,10 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared
             {
                 if (evnt.IsNull())
                     continue;
-                
-                AddOutput(evnt.ToString(), ConnectionType.Event, Realm);
-                AddInput($"Select{evnt.ToString()}", ConnectionType.Event);
+
+                string eventName = (evnt == null || evnt.IsNull()) ? "Event" : evnt.ToString();
+                AddOutput(eventName, ConnectionType.Event, Realm);
+                AddInput($"Select{eventName}", ConnectionType.Event, Realm);
             }
         }
 
@@ -38,10 +39,13 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared
             // An event was edited
             if (args.Item.Parent.Name == "Events")
             {
-                EntityInput input = GetInput($"Select{args.OldValue}", ConnectionType.Event);
-                EntityOutput output = GetOutput(args.OldValue.ToString(), ConnectionType.Event);
-                input.Name = args.NewValue.ToString();
-                output.Name = $"Select{args.NewValue}";
+                string oldName = (args.OldValue == null || ((CString)args.OldValue).IsNull()) ? "Event" : args.OldValue.ToString();
+                EntityInput input = GetInput($"Select{oldName}", ConnectionType.Event);
+                EntityOutput output = GetOutput(oldName, ConnectionType.Event);
+                // Update names to the new value
+                string newName = args.NewValue.ToString();
+                input.Name = newName;
+                output.Name = $"Select{newName}";
                 RefreshCache();
             }
             // The list itself was edited
@@ -52,6 +56,9 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.Nodes.TypeMapping.Shared
                     case ItemModifiedTypes.Insert:
                     case ItemModifiedTypes.Add:
                     {
+                        CString eventName = (dynamic)args.NewValue;
+                        if (eventName.IsNull())
+                            break;
                         AddOutput(args.NewValue.ToString(), ConnectionType.Event, Realm);
                         AddInput($"Select{args.NewValue.ToString()}", ConnectionType.Event, Realm);
                     } break;


### PR DESCRIPTION
1. If an interface field, link, or event input/output is a duplicate, it will crash. If a duplicate is found it will ignore it

2. SelectEvents creates a "null" string when adding to the index. Will check for a null string to prevent the crash

3. All Hub-Related entities (i.e. IntHubEntityData) would crash upon removing an index. Was a casting issue. Converting to int32 and null checking fixed crashing